### PR TITLE
Fix Response Header (gomcksvr-2)

### DIFF
--- a/src/routes/route_manager.go
+++ b/src/routes/route_manager.go
@@ -69,6 +69,7 @@ func (routeManager routeManager) ProcessAPIRequest(writer http.ResponseWriter, r
 		}
 	}
 
+	writer.Header().Add("content-type", "application/json")
 	writer.WriteHeader(statusCode)
 	_, err := writer.Write([]byte(responseBody))
 


### PR DESCRIPTION
Motivation
----
The response header is incorrectly displaying `text` as the content-type when the response is json

Modifications
----
* Added `content-type` header with json type for correct response type

Result
----
The mock server should be returning json as the response type