### PR TITLE
Fix Various Bugs (route matching, unit tests, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,21 @@ In the above example, 3 routes will be generated:
  - 2 routes for the url `/{tenantId}/hooray/{id}`:
    - `POST`: returns 201 status code with a body that will have the `tenantId` and `id` fields replaced by the respective url parameters
    - `GET`: reeturns a 200 status code with an empty body
-   
+
+---
+## Local Testing With Docker
+1. Build the image locally
+From within the src directory, you can run the following command:
+`docker build -t gomockserver:dev .`
+
+2. Use the image in a docker-compose file:
+`image: gomockserver:dev`
+
+---
+## Docker Image
+The related docker image can be found here:
+https://hub.docker.com/r/blankdev117/gomockserver
+
 ---
 ## Contibrutions/Feature requests
 

--- a/src/io/request.go
+++ b/src/io/request.go
@@ -1,6 +1,7 @@
 package io
 
 import (
+	"bytes"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -47,6 +48,9 @@ func NewRequest(httpRequest *http.Request, routeParts []string) (request, error)
 		return DefaultRequest(), err
 	}
 
+	// Remove byte order mark
+	// Reference: https://stackoverflow.com/questions/31398044/got-error-invalid-character-%C3%AF-looking-for-beginning-of-value-from-json-unmar
+	bodyBuffer = bytes.TrimPrefix(bodyBuffer, []byte("\xef\xbb\xbf"))
 	body, err := utils.ConvertBytesToMap(bodyBuffer)
 
 	if err != nil {

--- a/src/io/response.go
+++ b/src/io/response.go
@@ -33,7 +33,7 @@ func NewResponse(statusCode int, body map[string]interface{}, headers map[string
 func formatHeaders(headers map[string]string) map[string]string {
 	formattedHeaders := map[string]string{}
 
-	if formattedHeaders != nil {
+	if headers != nil {
 		for key := range headers {
 			headerKey := strings.ToLower(key)
 			formattedHeaders[headerKey] = headers[key]

--- a/src/routes/route.go
+++ b/src/routes/route.go
@@ -36,6 +36,10 @@ func (route Route) DoesPathMatch(path string) RouteMatch {
 	pathParts := strings.Split(path, "/")
 
 	for index, part := range pathParts {
+		if index >= len(route.RouteParts) {
+			return NoMatch
+		}
+
 		routePart := route.RouteParts[index]
 		if routePart == "*" {
 			return PartialMatch

--- a/src/test/io/response_test.go
+++ b/src/test/io/response_test.go
@@ -13,7 +13,7 @@ func TestGetJSONResponseNilBodyReturnsEmptyString(t *testing.T) {
 	// Arrange
 	assert := assert.New(t)
 
-	response := io.NewResponse(200, nil)
+	response := io.NewResponse(200, nil, nil)
 
 	// Act
 	result, err := io.GetJSONResponse(response, nil)
@@ -27,7 +27,7 @@ func TestGetJSONResponseEmptyBodyReturnsEmptyString(t *testing.T) {
 	// Arrange
 	assert := assert.New(t)
 
-	response := io.NewResponse(200, map[string]interface{}{})
+	response := io.NewResponse(200, map[string]interface{}{}, nil)
 
 	// Act
 	result, err := io.GetJSONResponse(response, nil)
@@ -45,7 +45,7 @@ func TestGetJSONResponseNilUrlParamsReturnsBodyAsJSONString(t *testing.T) {
 		"Test": "Hi",
 		"Oh":   10,
 	}
-	response := io.NewResponse(200, jsonBody)
+	response := io.NewResponse(200, jsonBody, nil)
 
 	// Act
 	result, err := io.GetJSONResponse(response, nil)
@@ -63,7 +63,7 @@ func TestGetJSONResponseEmptyUrlParamsReturnsBodyAsJSONString(t *testing.T) {
 		"Test": "Hi",
 		"Oh":   10,
 	}
-	response := io.NewResponse(200, jsonBody)
+	response := io.NewResponse(200, jsonBody, nil)
 
 	urlParams := map[string]string{}
 
@@ -86,7 +86,7 @@ func TestGetJSONResponseReplacesDesignatedUrlParamsInJSONString(t *testing.T) {
 		"Color":     "{{color}}",
 		"Secondary": "{color}",
 	}
-	response := io.NewResponse(200, jsonBody)
+	response := io.NewResponse(200, jsonBody, nil)
 
 	urlParams := map[string]string{
 		"{color}": "red",


### PR DESCRIPTION
Motivation
----
* There is an index out of range issue that arises when comparing requested routes to configure routes that are shorter
* README missing a few small bits of information that might be helpful
* A byte code issue is causing a crash when parsing the body of a request

Modifications
----
* Adjusted route matching to break out early when routes do not have same length (fails match)
* Updated io request to trim the byte code causing the crash
* Updated README

Result
-----
Gomockserver should not crash for the reasons above